### PR TITLE
add test cases to check if it's not .txt/.md/.json/folder

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -9,4 +9,9 @@ For contributors:
 -Run format.bat, tidy.bat and make relevant changes/re-test code before final submission     
 -OR import GASClang-settings.json in Clang Power Tools to perform linting and formatting in Visual Studio     
 -Compile using c++std=17 in your compiler of choice i.e        
-`g++ -std=c++17 gasMain.cpp gasHeader.h -o gas`   
+`g++ -std=c++17 gasMain.cpp gasHeader.hpp -o gas`   
+
+
+For testing:   
+-Compile with test.cpp i.e     
+`g++ -std=c++17 test.cpp catch.hpp gasHeader.hpp -o gas` 

--- a/test.cpp
+++ b/test.cpp
@@ -24,16 +24,36 @@ TEST_CASE("isText() Testing", "[istext]") {
 	REQUIRE(isText("The Adventure of the Speckled Band.txt") == true);
 }
 
+TEST_CASE("isText() Testing (not .txt file)", "[istext]") {
+	REQUIRE(isText("The Adventure of the Speckled Band.md") == false);
+	REQUIRE(isText("The Adventure of the Speckled Band") == false);
+}
+
 TEST_CASE("isMarkDown() Testing", "[ismarkdown]") {
 	REQUIRE(isMarkDown("readme.md") == true);
+}
+
+TEST_CASE("isMarkDown() Testing (not .md file)", "[ismarkdown]") {
+	REQUIRE(isMarkDown("The Adventure of the Speckled Band.txt") == false);
+	REQUIRE(isMarkDown("The Adventure of the Speckled Band") == false);
 }
 
 TEST_CASE("isFolder() Testing", "[isfolder]") {
 	REQUIRE(isFolder("./dist") == true);
 }
 
+TEST_CASE("isFolder() Testing (not folder)", "[isfolder]") {
+	REQUIRE(isFolder("The Adventure of the Speckled Band.txt") == false);
+	REQUIRE(isFolder("The Adventure of the Speckled Band.json") == false);
+}
+
 TEST_CASE("isJson() Testing", "[isjson]") {
 	REQUIRE(isJson("ssg-config.json") == true);
+}
+
+TEST_CASE("isJson() Testing (not .json file)", "[isjson]") {
+	REQUIRE(isJson("The Adventure of the Speckled Band.txt") == false);
+	REQUIRE(isJson("The Adventure of the Speckled Band") == false);
 }
 
 TEST_CASE("getJsonValue() Testing", "[getjsonvalue]") {


### PR DESCRIPTION
I saw you have 4 functions to check for correct file/folder input:

* bool isText(std::string inLine);
* bool isMarkDown(std::string inLine);
* bool isFolder(std::string inLine);
* bool isJson(std::string inLine);

You only had the test cases to test if these functions are returning true values. I added test cases to test if these functions are returning false values correctly.